### PR TITLE
Setup Jest+Puppeteer test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Space Virtual Test Setup
+
+This repository includes automated tests using **Jest** and **Puppeteer**.
+
+## Instalaci\xC3\xB3n
+
+1. Aseg\xC3\xBArate de tener [Node.js](https://nodejs.org/) instalado.
+2. Instala las dependencias:
+
+```bash
+npm install
+```
+
+## Ejecutar pruebas
+
+Para ejecutar las pruebas usa:
+
+```bash
+npm test
+```
+
+Esto abrir\xC3\xA1 la escena `aframe_colisiones/index.html` en un navegador sin cabeza y verificar\xC3\xA1 que no existan errores en la consola durante la inicializaci\xC3\xB3n.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spacevirtual.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "puppeteer": "^22.6.3"
+  }
+}

--- a/tests/scene-init.test.js
+++ b/tests/scene-init.test.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+describe('A-Frame scene', () => {
+  test('initializes without console errors', async () => {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    const errors = [];
+
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+
+    page.on('pageerror', err => errors.push(err.message));
+
+    const filePath = 'file://' + path.resolve(__dirname, '../aframe_colisiones/index.html');
+    await page.goto(filePath);
+    await page.waitForSelector('a-scene');
+    await page.waitForTimeout(1000);
+    await browser.close();
+
+    expect(errors).toEqual([]);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary
- initialize Node project with Jest and Puppeteer
- add a Puppeteer test that loads `aframe_colisiones/index.html`
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5b24d708324bde7bc1882209ee5