### PR TITLE
Add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,11 @@
     <!-- A-Frame -->
     <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
-    <!-- Física 
+    <!-- Física
     <script src="https://cdn.jsdelivr.net/npm/aframe-physics-system@4.0.1/dist/aframe-physics-system.min.js"></script>-->
+
+    <!-- Controles para dispositivos móviles -->
+    <script src="https://cdn.jsdelivr.net/npm/aframe-extras@6.1.1/dist/aframe-extras.min.js"></script>
 
     <!-- Joystick alternativo forzado -->
     <script src="https://cdn.jsdelivr.net/npm/aframe-joystick-component@3.1.0/dist/aframe-joystick-component.min.js"></script>
@@ -43,6 +46,7 @@
           camera
           look-controls
           wasd-controls
+          touch-controls
           joystick-controls="mode: movement"
           position="20 1.6 -10">
         </a-entity>


### PR DESCRIPTION
## Summary
- enable extra controls via aframe-extras
- add touch-controls component to the camera entity

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a699a94c8324998efd87ede807f8