### PR TITLE
Add cursor fuse progress animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,9 @@
         touch-controls
         joystick-controls="mode: movement"
         position="20 1.6 -10">
-        <a-cursor id="cursor" fuse="true" fuseTimeout="3000" raycaster="objects: .info-target" position="0 0 -1" geometry="primitive: ring; radiusInner: 0.005; radiusOuter: 0.008" material="color: black; shader: flat"></a-cursor>
+        <a-cursor id="cursor" fuse="true" fuseTimeout="3000" raycaster="objects: .info-target" position="0 0 -1" geometry="primitive: ring; radiusInner: 0.005; radiusOuter: 0.008" material="color: black; shader: flat" cursor-progress>
+          <a-ring id="cursorProgress" position="0 0 -0.001" radius-inner="0.009" radius-outer="0.011" color="#4CAF50" theta-length="0" visible="false"></a-ring>
+        </a-cursor>
       </a-entity>
 
       <!-- Luces -->

--- a/js/app.js
+++ b/js/app.js
@@ -17,3 +17,35 @@ AFRAME.registerComponent('info-listener', {
     });
   }
 });
+
+AFRAME.registerComponent('cursor-progress', {
+  init: function () {
+    const progressRing = this.el.querySelector('#cursorProgress');
+    if (!progressRing) { return; }
+
+    const start = () => {
+      progressRing.setAttribute('visible', true);
+      progressRing.removeAttribute('animation__reset');
+      progressRing.setAttribute('animation__fill', {
+        property: 'geometry.thetaLength',
+        from: 0,
+        to: 360,
+        dur: 3000,
+        easing: 'linear'
+      });
+    };
+
+    const reset = () => {
+      progressRing.setAttribute('animation__reset', {
+        property: 'geometry.thetaLength',
+        to: 0,
+        dur: 0
+      });
+      progressRing.setAttribute('visible', false);
+    };
+
+    this.el.addEventListener('fusing', start);
+    this.el.addEventListener('mouseleave', reset);
+    this.el.addEventListener('click', reset);
+  }
+});


### PR DESCRIPTION
## Summary
- animate the cursor when fusing with targets
- show a progress ring that fills over three seconds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b4b600088324b146ccc6c2a3249f