### PR TITLE
Ensure cursor fuse animation restarts on each hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,9 @@
         touch-controls
         joystick-controls="mode: movement"
         position="20 1.6 -10">
-        <a-cursor id="cursor" fuse="true" fuseTimeout="3000" raycaster="objects: .info-target" position="0 0 -1" geometry="primitive: ring; radiusInner: 0.005; radiusOuter: 0.008" material="color: black; shader: flat"></a-cursor>
+        <a-cursor id="cursor" fuse="true" fuseTimeout="3000" raycaster="objects: .info-target" position="0 0 -1" geometry="primitive: ring; radiusInner: 0.005; radiusOuter: 0.008" material="color: black; shader: flat" cursor-progress>
+          <a-ring id="cursorProgress" position="0 0 -0.001" radius-inner="0.009" radius-outer="0.011" color="#4CAF50" theta-length="0" visible="false"></a-ring>
+        </a-cursor>
       </a-entity>
 
       <!-- Luces -->

--- a/js/app.js
+++ b/js/app.js
@@ -17,3 +17,52 @@ AFRAME.registerComponent('info-listener', {
     });
   }
 });
+
+AFRAME.registerComponent('cursor-progress', {
+  init: function () {
+    const progressRing = this.el.querySelector('#cursorProgress');
+    if (!progressRing) { return; }
+
+    let intersected = false;
+
+    const start = () => {
+      progressRing.removeAttribute('animation__fill');
+      progressRing.removeAttribute('animation__reset');
+      progressRing.setAttribute('visible', true);
+      progressRing.setAttribute('animation__fill', {
+        property: 'geometry.thetaLength',
+        from: 0,
+        to: 360,
+        dur: 3000,
+        easing: 'linear'
+      });
+    };
+
+    const reset = () => {
+      progressRing.removeAttribute('animation__fill');
+      progressRing.setAttribute('animation__reset', {
+        property: 'geometry.thetaLength',
+        to: 0,
+        dur: 0
+      });
+      progressRing.setAttribute('visible', false);
+    };
+
+    this.el.addEventListener('raycaster-intersection', () => {
+      intersected = true;
+      start();
+    });
+
+    this.el.addEventListener('raycaster-intersection-cleared', () => {
+      intersected = false;
+      reset();
+    });
+
+    this.el.addEventListener('click', () => {
+      reset();
+      if (intersected) {
+        start();
+      }
+    });
+  }
+});

--- a/js/app.js
+++ b/js/app.js
@@ -23,11 +23,9 @@ AFRAME.registerComponent('cursor-progress', {
     const progressRing = this.el.querySelector('#cursorProgress');
     if (!progressRing) { return; }
 
-    let intersected = false;
-
     const start = () => {
       progressRing.removeAttribute('animation__fill');
-      progressRing.removeAttribute('animation__reset');
+      progressRing.setAttribute('geometry', 'thetaLength', 0);
       progressRing.setAttribute('visible', true);
       progressRing.setAttribute('animation__fill', {
         property: 'geometry.thetaLength',
@@ -40,27 +38,16 @@ AFRAME.registerComponent('cursor-progress', {
 
     const reset = () => {
       progressRing.removeAttribute('animation__fill');
-      progressRing.setAttribute('animation__reset', {
-        property: 'geometry.thetaLength',
-        to: 0,
-        dur: 0
-      });
+      progressRing.setAttribute('geometry', 'thetaLength', 0);
       progressRing.setAttribute('visible', false);
     };
 
-    this.el.addEventListener('raycaster-intersection', () => {
-      intersected = true;
-      start();
-    });
-
-    this.el.addEventListener('raycaster-intersection-cleared', () => {
-      intersected = false;
-      reset();
-    });
-
+    this.el.addEventListener('fusing', start);
+    this.el.addEventListener('mouseleave', reset);
     this.el.addEventListener('click', () => {
       reset();
-      if (intersected) {
+      // Restart immediately if still hovering over a target
+      if (this.el.components.raycaster.intersectedEls.length) {
         start();
       }
     });


### PR DESCRIPTION
## Summary
- update `cursor-progress` component to start on raycaster intersections
- reset and restart progress after clicks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b4b600088324b146ccc6c2a3249f