### PR TITLE
Enable automatic info targets on textured meshes

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,8 @@
         id="sala"
         src="#sala3D"
         position="0 0.1 0"
-        scale="1 1 1">
+        scale="1 1 1"
+        auto-info-from-textures>
       </a-gltf-model>
 
       <!-- Ejemplos de im\xC3\xA1genes con informaci\xC3\xB3n -->

--- a/js/app.js
+++ b/js/app.js
@@ -47,3 +47,34 @@ AFRAME.registerComponent('cursor-progress', {
 
   }
 });
+
+AFRAME.registerComponent('auto-info-from-textures', {
+  schema: { textPrefix: { type: 'string', default: 'Info de' } },
+  init: function () {
+    this.el.addEventListener('model-loaded', () => {
+      const mesh = this.el.getObject3D('mesh');
+      if (!mesh) { return; }
+      mesh.traverse(node => {
+        if (!node.isMesh || !node.material || !node.material.map) { return; }
+        const box = new THREE.Box3().setFromObject(node);
+        const center = box.getCenter(new THREE.Vector3());
+
+        const wrapper = document.createElement('a-entity');
+        wrapper.setAttribute('position', center);
+        const infoText = `${this.data.textPrefix} ${node.name}`.trim();
+        wrapper.setAttribute('info-listener', `text: ${infoText}`);
+        wrapper.classList.add('info-target');
+
+        const textEl = document.createElement('a-text');
+        textEl.classList.add('info-text');
+        textEl.setAttribute('value', infoText);
+        textEl.setAttribute('visible', 'false');
+        textEl.setAttribute('align', 'center');
+        textEl.setAttribute('position', '0 0 0.1');
+        wrapper.appendChild(textEl);
+
+        this.el.sceneEl.appendChild(wrapper);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- auto-detect textured meshes and attach info targets
- enable component on main model

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ac2aebf88324916b07627ffcd9d2