### PR TITLE
Add text mapping for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 
     <!-- Joystick alternativo forzado -->
     <script src="https://cdn.jsdelivr.net/npm/aframe-joystick-component@3.1.0/dist/aframe-joystick-component.min.js"></script>
+    <script src="js/image-texts.js"></script>
     <script src="js/app.js"></script>
   </head>
   <body>
@@ -34,7 +35,8 @@
         id="sala"
         src="#sala3D"
         position="0 0.1 0"
-        scale="1 1 1">
+        scale="1 1 1"
+        auto-info-from-textures>
       </a-gltf-model>
 
       <!-- Ejemplos de im\xC3\xA1genes con informaci\xC3\xB3n -->

--- a/js/app.js
+++ b/js/app.js
@@ -47,3 +47,40 @@ AFRAME.registerComponent('cursor-progress', {
 
   }
 });
+
+AFRAME.registerComponent('auto-info-from-textures', {
+  schema: { textPrefix: { type: 'string', default: 'Info de' } },
+  init: function () {
+    this.el.addEventListener('model-loaded', () => {
+      const mesh = this.el.getObject3D('mesh');
+      if (!mesh) { return; }
+      mesh.traverse(node => {
+        if (!node.isMesh || !node.material || !node.material.map) { return; }
+
+        const box = new THREE.Box3().setFromObject(node);
+        const center = box.getCenter(new THREE.Vector3());
+
+        const target = document.createElement('a-sphere');
+        target.setAttribute('radius', '0.05');
+        target.setAttribute('position', center);
+        target.setAttribute('material', 'visible: false; opacity: 0');
+
+        const imgName = node.material.map.name || node.name;
+        const infoText = (window.IMAGE_TEXTS && window.IMAGE_TEXTS[imgName]) ||
+          `${this.data.textPrefix} ${imgName}`.trim();
+        target.setAttribute('info-listener', `text: ${infoText}`);
+        target.classList.add('info-target');
+
+        const textEl = document.createElement('a-text');
+        textEl.classList.add('info-text');
+        textEl.setAttribute('value', infoText);
+        textEl.setAttribute('visible', 'false');
+        textEl.setAttribute('align', 'center');
+        textEl.setAttribute('position', '0 0 0.1');
+        target.appendChild(textEl);
+
+        this.el.sceneEl.appendChild(target);
+      });
+    });
+  }
+});

--- a/js/image-texts.js
+++ b/js/image-texts.js
@@ -1,0 +1,13 @@
+window.IMAGE_TEXTS = {
+  "1439.jpg": "Texto de 1439.jpg",
+  "1442.jpg": "Texto de 1442.jpg",
+  "1452.jpg": "Texto de 1452.jpg",
+  "1453.jpg": "Texto de 1453.jpg",
+  "1469.jpg": "Texto de 1469.jpg",
+  "CMU_1K_alb.png": "Texto de CMU_1K_alb.png",
+  "PORTADA.jpg": "Texto de PORTADA.jpg",
+  "Tile_Travertine_2inch.jpg": "Texto de Tile_Travertine_2inch.jpg",
+  "a.jpg": "Texto de a.jpg",
+  "b.jpg": "Texto de b.jpg",
+  "red.jpg": "Texto de red.jpg"
+};


### PR DESCRIPTION
## Summary
- create `image-texts.js` with placeholders for each image name
- load that mapping in `index.html`
- show mapped text in `auto-info-from-textures`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ac2aebf88324916b07627ffcd9d2