### PR TITLE
Fix automatic info text mapping

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -57,6 +57,19 @@ AFRAME.registerComponent('auto-info-from-textures', {
       mesh.traverse(node => {
         if (!node.isMesh || !node.material || !node.material.map) { return; }
 
+        const box = new THREE.Box3().setFromObject(node);
+        const center = box.getCenter(new THREE.Vector3());
+
+        const target = document.createElement('a-sphere');
+        target.setAttribute('radius', '0.05');
+        target.setAttribute('position', center);
+        target.setAttribute('material', 'visible: false; opacity: 0');
+
+        const imgName = node.material.map.name || node.name;
+        const infoText = (window.IMAGE_TEXTS && window.IMAGE_TEXTS[imgName]) ||
+          `${this.data.textPrefix} ${imgName}`.trim();
+        target.setAttribute('info-listener', `text: ${infoText}`);
+        target.classList.add('info-target');
 
         const textEl = document.createElement('a-text');
         textEl.classList.add('info-text');
@@ -64,7 +77,9 @@ AFRAME.registerComponent('auto-info-from-textures', {
         textEl.setAttribute('visible', 'false');
         textEl.setAttribute('align', 'center');
         textEl.setAttribute('position', '0 0 0.1');
+        target.appendChild(textEl);
 
+        this.el.sceneEl.appendChild(target);
       });
     });
   }


### PR DESCRIPTION
## Summary
- complete logic in `auto-info-from-textures` to create info texts based on mesh textures

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6bbe8408324afbd013d5c5e6284