### PR TITLE
Remove gradient sky attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
         <img id="painting1" src="PORTADA.jpg">
        
       </a-assets>
-      <!-- Cielo con degradado de azul a blanco -->
-      <a-sky gradient-sky="topColor: #88ccff; bottomColor: #ffffff"></a-sky>
+      <!-- Cielo -->
+      <a-sky color="#88ccff"></a-sky>
 
       <!-- Modelo de sala -->
       <a-gltf-model


### PR DESCRIPTION
## Summary
- remove the `gradient-sky` component so the scene no longer warns

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6ebe6b083249c7f11947a60463b