### PR TITLE
Add numbering overlay for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <script src="libs/aframe-joystick-component.min.js"></script>-->
     <script src="js/image-texts.js"></script>
     <script src="js/app.js"></script>
+    <script src="js/add-numbers.js"></script>
     
     <style>
       #loading-screen {

--- a/js/add-numbers.js
+++ b/js/add-numbers.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const images = document.querySelectorAll('a-image');
+  let count = 0;
+  images.forEach(img => {
+    const src = (img.getAttribute('src') || '').toLowerCase();
+    if (src.includes('portada.jpg') || src === '#painting1') {
+      return; // Skip numbering for the cover image
+    }
+
+    count += 1;
+    const numEl = document.createElement('a-text');
+    numEl.setAttribute('value', String(count));
+    numEl.setAttribute('color', '#ffffff');
+    numEl.setAttribute('align', 'right');
+    numEl.setAttribute('baseline', 'top');
+    numEl.setAttribute('width', '0.5');
+
+    const scaleAttr = img.getAttribute('scale');
+    let offsetX = 0.5;
+    let offsetY = 0.5;
+    if (scaleAttr) {
+      const parts = scaleAttr.split(/\s+/).map(parseFloat);
+      if (parts.length >= 2) {
+        if (!isNaN(parts[0])) offsetX = parts[0] / 2;
+        if (!isNaN(parts[1])) offsetY = parts[1] / 2;
+      }
+    }
+    numEl.setAttribute('position', `${offsetX} ${offsetY} 0.01`);
+
+    img.appendChild(numEl);
+  });
+});


### PR DESCRIPTION
## Summary
- script to label images sequentially at load time
- include new script in the index page
- skip numbering for the `PORTADA.jpg` cover image

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29461dbc8324819c8663b5d9ebe7