### PR TITLE
Añade margen para el scroll en el overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
 
     #overlay img, #overlay video, #overlay audio, #overlay iframe{display:block;width:100%;height:auto;background:#000}
     #overlay iframe{aspect-ratio:16/9;border:0}
-    .ov-scroll{flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;}#ov-media{width:100%;max-width:100%;overflow:hidden;}#overlay img,#overlay video,#overlay audio,#overlay iframe{display:block;width:100%;max-width:100%;height:auto;background:#000;}#overlay iframe{aspect-ratio:16/9;border:0;}
+    .ov-scroll{flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;padding-right:10px;scrollbar-gutter:stable both-edges;}#ov-media{width:100%;max-width:100%;overflow:hidden;}#overlay img,#overlay video,#overlay audio,#overlay iframe{display:block;width:100%;max-width:100%;height:auto;background:#000;}#overlay iframe{aspect-ratio:16/9;border:0;}
 
     .tooltip{position:fixed;z-index:4;padding:4px 6px;font-size:11px;color:#cbd5e1;background:#0b1220cc;border:1px solid var(--line);border-radius:6px;transform:translate(-50%,-120%);pointer-events:none}
 


### PR DESCRIPTION
## Resumen
- agrega un margen interno en el panel lateral para evitar que la barra de desplazamiento cubra el texto
- reserva espacio estable para la barra asegurando una lectura cómoda

## Pruebas
- no se ejecutaron pruebas (cambios de estilo)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d74f108208324b49aac3d6f1754bf)