### PR TITLE
Remove help panel box styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,13 @@
 
     .help{
       position:fixed;left:12px;top:108px;z-index:5;
-      background:rgba(15,23,42,.7);backdrop-filter:blur(6px);
-      border:1px solid var(--line);border-radius:10px;padding:10px 12px;font-size:12px;color:var(--muted);
-      user-select:none;max-width:min(640px,calc(100% - 24px))
+      font-size:12px;color:var(--muted);
+      user-select:none;max-width:min(640px,calc(100% - 24px));
+      padding:0;
+      background:none;
+      border:none;
+      border-radius:0;
+      backdrop-filter:none;
     }
     .help b{color:var(--fg)}
 


### PR DESCRIPTION
## Summary
- remove the help instruction panel's background, border, and padding to eliminate the box appearance

## Testing
- no tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d76364170832485575ff43287309b)