### PR TITLE
Limitar ancho del overlay del título al 30%

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Nube 3D · Ensayo sobre Estética Sintiente</title>
+  <title>Nube 3D · Estética Sintiente</title>
 
   <!-- Import Map: permite usar "three" como specifier en navegador -->
   <script type="importmap">
@@ -33,8 +33,9 @@
       position:fixed;
       top:0;
       left:0;
-      right:0;
+      right:auto;
       z-index:6;
+      width:30vw;
       background:rgba(15,23,42,.88);
       backdrop-filter:blur(8px);
       border-bottom:1px solid var(--line);
@@ -73,7 +74,7 @@
       top:18px;
       bottom:18px;
       z-index:10;
-      width:min(480px,calc(100% - 36px));
+      width:min(30vw,calc(100% - 36px));
       background:rgba(15,23,42,.72);
       backdrop-filter:blur(6px);
       border:1px solid var(--line);
@@ -155,8 +156,8 @@
 </head>
 <body>
   <header id="intro">
-    <h1>Ensayo · Estética Sintiente — ejes invisibles</h1>
-    <p>Explora un mapa 3D de obras, teorías y tecnologías. Cada punto es un caso. X: año · Y: grado sintiente · Z: cercanía científica. Haz clic en un nodo para leer.</p>
+    <h1>Estética Sintiente</h1>
+    <p>Explora un mapa 3D de obras, teorías y tecnologías. Cada punto es un caso.<br>X: año<br>Y: grado sintiente<br>Z: cercanía científica.<br>Haz clic en un nodo para leer.</p>
   </header>
   <div class="help"></div>
 


### PR DESCRIPTION
## Summary
- ajustar el encabezado superpuesto `#intro` para ocupar el 30 % del ancho de la ventana y liberarlo del borde derecho para evitar el ancho completo

## Testing
- no se ejecutaron pruebas (no aplicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7c6fa1388324ac7edc6c0a4411db)