### PR TITLE
Separar en párrafos el texto del nodo central

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,13 +449,12 @@
       id:'centro',
       title:'Hacia una Estética Sintiente',
       subtitle:'Omar Jaimes Rew',
-      text: `Este ensayo  se articula a partir de la visualización de datos como herramienta metodológica para la investigación y la práctica curatorial. Su estructura formal se inspira en una ecuación de regresión lineal: un modelo tridimensional que mapea, en tres dimensiones interrelacionadas, diversas piezas artísticas con el objetivo de evidenciar su pertinencia, sus tensiones y los patrones que configuran la emergencia de una “estética sintiente”.
-
-Comencemos por delimitar el término “sintiente”. Habitamos un entorno donde las tecnologías digitales se han expandido de forma sistemática. Sistemas de inteligencia artificial perciben el mundo mediante cámaras, micrófonos, sensores de profundidad, temperatura y otros dispositivos, integrados en objetos cotidianos como el teléfono móvil. Esta infraestructura técnico-perceptiva configura entornos poblados por artefactos capaces de captar información, procesarla y reaccionar a su contexto. Sin embargo, esa capacidad de detección y respuesta no basta para afirmar que estos objetos “sienten”.
-
-Sentir supone más que gestionar entradas de datos. Exige la posibilidad de una interioridad mínima, una organización propia de la experiencia que interpreta, valora y jerarquiza lo percibido. Desde la filosofía de la mente y ciertas perspectivas fenomenológicas, la sintiencia se vincula con una experiencia situada, encarnada y autoreferencial, no reducible al cálculo ni a la mera correlación estadística. En este marco, los sistemas actuales pueden describirse como sensibles a variables, pero no como entidades sintientes.
-
-En el campo del arte, la incorporación de estas tecnologías ha dado lugar a nuevas categorías, entre ellas el arte interactivo, entendido como aquel conjunto de prácticas en las que la obra ajusta su comportamiento, configuración o apariencia en función de la acción del público o de las variaciones del entorno. El objetivo de este ensayo se ancla en discutir qué tan cerca o lejos nos encontramos de dispositivos artísticos sintientes: obras concebidas como sistemas capaces de percibir, procesar e interpretar información de su contexto y, a partir de ello, modular su forma, su respuesta y su efecto estético. Pensar una “estética sintiente” implica desplazar la obra de arte de la condición de objeto estable hacia la de agente perceptivo que negocia, en tiempo real, su modo de aparecer.`,
+      text:[
+        'Este ensayo se articula a partir de la visualización de datos como herramienta metodológica para la investigación y la práctica curatorial. Su estructura formal se inspira en una ecuación de regresión lineal: un modelo tridimensional que mapea, en tres dimensiones interrelacionadas, diversas piezas artísticas con el objetivo de evidenciar su pertinencia, sus tensiones y los patrones que configuran la emergencia de una “estética sintiente”.',
+        'Comencemos por delimitar el término “sintiente”. Habitamos un entorno donde las tecnologías digitales se han expandido de forma sistemática. Sistemas de inteligencia artificial perciben el mundo mediante cámaras, micrófonos, sensores de profundidad, temperatura y otros dispositivos, integrados en objetos cotidianos como el teléfono móvil. Esta infraestructura técnico-perceptiva configura entornos poblados por artefactos capaces de captar información, procesarla y reaccionar a su contexto. Sin embargo, esa capacidad de detección y respuesta no basta para afirmar que estos objetos “sienten”.',
+        'Sentir supone más que gestionar entradas de datos. Exige la posibilidad de una interioridad mínima, una organización propia de la experiencia que interpreta, valora y jerarquiza lo percibido. Desde la filosofía de la mente y ciertas perspectivas fenomenológicas, la sintiencia se vincula con una experiencia situada, encarnada y autoreferencial, no reducible al cálculo ni a la mera correlación estadística. En este marco, los sistemas actuales pueden describirse como sensibles a variables, pero no como entidades sintientes.',
+        'En el campo del arte, la incorporación de estas tecnologías ha dado lugar a nuevas categorías, entre ellas el arte interactivo, entendido como aquel conjunto de prácticas en las que la obra ajusta su comportamiento, configuración o apariencia en función de la acción del público o de las variaciones del entorno. El objetivo de este ensayo se ancla en discutir qué tan cerca o lejos nos encontramos de dispositivos artísticos sintientes: obras concebidas como sistemas capaces de percibir, procesar e interpretar información de su contexto y, a partir de ello, modular su forma, su respuesta y su efecto estético. Pensar una “estética sintiente” implica desplazar la obra de arte de la condición de objeto estable hacia la de agente perceptivo que negocia, en tiempo real, su modo de aparecer.'
+      ],
       media:{
         type:'image',
         src:'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="600" height="338"><rect width="100%" height="100%" fill="black"/><text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Arial" font-size="18">Hacia una Estética Sintiente</text><text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Arial" font-size="14">Omar Jaimes Rew</text></svg>'
@@ -722,9 +721,17 @@ function buildMediaEl(media){
         meta.textContent = `Autor: ${CENTRAL_NODE.subtitle || 'Omar Jaimes Rew'}`;
         ovText.appendChild(meta);
 
-        const p = document.createElement('p');
-        p.textContent = CENTRAL_NODE.text;
-        ovText.appendChild(p);
+        const paragraphs = Array.isArray(CENTRAL_NODE.text)
+          ? CENTRAL_NODE.text
+          : (CENTRAL_NODE.text || '').split(/\n\s*\n/);
+
+        paragraphs.forEach(par => {
+          const trimmed = par.trim();
+          if(!trimmed) return;
+          const p = document.createElement('p');
+          p.textContent = trimmed;
+          ovText.appendChild(p);
+        });
 
         const pNote = document.createElement('p');
         pNote.textContent = 'Nodo conceptual más luminoso: máxima sintiencia implementada y máxima cercanía científica.';


### PR DESCRIPTION
## Summary
- reestructura el texto del nodo conceptual central como una lista de párrafos bien delimitados
- actualiza la lógica del overlay para renderizar cada párrafo por separado y mantener la legibilidad

## Testing
- not run (content change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d82ddb91083248202480c86694f0a)