### PR TITLE
Remove intro overlay luminosity note

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,10 +733,6 @@ function buildMediaEl(media){
           ovText.appendChild(p);
         });
 
-        const pNote = document.createElement('p');
-        pNote.textContent = 'Nodo conceptual más luminoso: máxima sintiencia implementada y máxima cercanía científica.';
-        ovText.appendChild(pNote);
-
         ovId.textContent = `ID: ${id}`;
       } else {
         const data = WORKS.find(w=>w.id===id);


### PR DESCRIPTION
## Summary
- remove the closing note from the central node overlay so the intro no longer repeats the luminosity description

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d845da6f0832485313c7fb4838fb0)