### PR TITLE
Adjust overlay widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
       top:18px;
       left:18px;
       bottom:18px;
-      width:clamp(260px,32vw,420px);
-      max-width:calc(100% - 36px);
+      width:min(20vw, calc(100% - 36px));
       display:flex;
       flex-direction:column;
       gap:clamp(14px,3vh,32px);


### PR DESCRIPTION
## Summary
- set the left overlay rail to occupy 20% of the viewport width while respecting page margins

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8921afbc832487b25fd794fbb8a9)