### PR TITLE
Reduce overlay opacity by 5%

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       box-sizing:border-box;
     }
     #intro{
-      background:rgba(15,23,42,.88);
+      background:rgba(15,23,42,.83);
       backdrop-filter:blur(8px);
       border:1px solid var(--line);
       border-radius:14px;
@@ -76,7 +76,7 @@
       font-size:12px;color:var(--muted);
       user-select:none;
       padding:12px 16px;
-      background:rgba(15,23,42,.72);
+      background:rgba(15,23,42,.67);
       border:1px solid var(--line);
       border-radius:12px;
       backdrop-filter:blur(6px);
@@ -90,7 +90,7 @@
       bottom:18px;
       z-index:10;
       width:min(30vw,calc(100% - 36px));
-      background:rgba(15,23,42,.72);
+      background:rgba(15,23,42,.67);
       backdrop-filter:blur(6px);
       border:1px solid var(--line);
       border-radius:14px;
@@ -134,11 +134,11 @@
     #overlay iframe{aspect-ratio:16/9;border:0}
     .ov-scroll{flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;padding-right:10px;scrollbar-gutter:stable both-edges;}#ov-media{width:100%;max-width:100%;overflow:hidden;}#overlay img,#overlay video,#overlay audio,#overlay iframe{display:block;width:100%;max-width:100%;height:auto;background:#000;}#overlay iframe{aspect-ratio:16/9;border:0;}
 
-    .tooltip{position:fixed;z-index:4;padding:4px 6px;font-size:11px;color:#cbd5e1;background:#0b1220cc;border:1px solid var(--line);border-radius:6px;transform:translate(-50%,-120%);pointer-events:none}
+    .tooltip{position:fixed;z-index:4;padding:4px 6px;font-size:11px;color:#cbd5e1;background:#0b1220bf;border:1px solid var(--line);border-radius:6px;transform:translate(-50%,-120%);pointer-events:none}
 
     /* HUD fija para datos de navegación */
     .hud{
-      background:rgba(15,23,42,.8);backdrop-filter:blur(6px);
+      background:rgba(15,23,42,.75);backdrop-filter:blur(6px);
       border:1px solid var(--line);border-radius:10px;padding:8px 10px;font-size:12px;color:var(--muted);
       min-width:260px
     }
@@ -148,7 +148,7 @@
 
     /* Panel de controles */
     .panel{
-      background:rgba(15,23,42,.8);backdrop-filter:blur(6px);
+      background:rgba(15,23,42,.75);backdrop-filter:blur(6px);
       border:1px solid var(--line);border-radius:10px;padding:10px 12px;font-size:12px;color:var(--muted);
       min-width:280px
     }


### PR DESCRIPTION
## Summary
- lower the opacity of overlay elements to soften their appearance
- adjust tooltip background alpha to match the new opacity level

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8c3a07408324b1949c17fc415729)