### PR TITLE
Fix scroll wheel zoom behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,8 @@
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
     controls.enablePan = true;
+    controls.zoomToCursor = true;
+    controls.zoomSpeed = 0.55;
     controls.minDistance = 1.2;
     controls.maxDistance = 120;
 
@@ -898,6 +900,10 @@ function buildMediaEl(media){
       pointerDown = null;
       updateHUD();
     });
+
+    renderer.domElement.addEventListener('wheel', e => {
+      toNDC(e);
+    }, { passive: true });
 
     function onResize(){
       const w = window.innerWidth, h = window.innerHeight;


### PR DESCRIPTION
## Summary
- enable orbit controls zoom to focus around the pointer when using the scroll wheel
- keep the raycasting coordinates in sync on wheel input to stabilise hover feedback while zooming

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e21125bd88324847b9d3e1508eee3)